### PR TITLE
Shrink the 'Help' icon to fit in line with text

### DIFF
--- a/src/primitives/Help.js
+++ b/src/primitives/Help.js
@@ -16,9 +16,9 @@ const Help = observer(({ children }) => (
   <Popover.Container>
     {state => (
       <HelpToggle as={Popover.Toggle} {...state}>
-        <Stack>
-          <Icon path={mdiCircle} size={1} color={darkgrey} />
-          <Icon path={mdiHelp} size={0.8} color={white} />
+        <Stack size={0.8} >
+          <Icon path={mdiCircle} size={0.8} color={darkgrey} />
+          <Icon path={mdiHelp} size={0.6} color={white} />
         </Stack>
 
         <Callout {...state}>{ children }</Callout>


### PR DESCRIPTION
Based on feedback from @sjiribarren:

> @Sean Campbell or @Grace looking good! very minor from quick look at it - can you make the ?'s in the symptoms smaller so that they don't throw off the spacing in the side effect list? looks like you can still upload multiple pictures at a time vs if hit retake that it would erase last picture taken. when I first click on photo upload it took me to my photo files. the second time opened right up for a picture. will play with some more tomorrow and get the translations in for my progress