### PR TITLE
Changes to My Progress and DateTime

### DIFF
--- a/src/Assembly.js
+++ b/src/Assembly.js
@@ -170,7 +170,8 @@ class Assembly extends React.Component {
     )
 
     this.survey_date = DateTime.local().setLocale(this.locale).toISODate()
-    this.survey_medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24)
+    this.survey_medication_time = "09:30"
+    // DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
     
     window.assembly = this
   }

--- a/src/Assembly.js
+++ b/src/Assembly.js
@@ -352,7 +352,8 @@ class Assembly extends React.Component {
         </Observer>
       </Content>
 
-      <Space />
+      {/* Temporarily deleting this to see how it effects the app */}
+      {/* <Space className="SPACE" /> */}
 
       <WhenAuthenticated account={this.participant_account} >
         <NavBar>

--- a/src/Assembly.js
+++ b/src/Assembly.js
@@ -169,9 +169,9 @@ class Assembly extends React.Component {
       }
     )
 
-    this.survey_date = DateTime.local().setLocale(this.locale).toISODate()
-    this.survey_medication_time = "09:30"
-    // DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
+    // For spanish version: Changed from .toISODate(), didn't notice any regression
+    this.survey_date = DateTime.local().setLocale(this.locale).toLocaleString()
+    this.survey_medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
     
     window.assembly = this
   }
@@ -249,11 +249,6 @@ class Assembly extends React.Component {
         },
       )
     }
-
-    this.survey_date = DateTime.local().setLocale(this.locale).toISODate();
-    this.survey_medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24)
-    this.survey_tookMedication = null
-    this.survey_notTakingMedicationReason = null
   }
 
   reportSymptoms() {
@@ -264,6 +259,13 @@ class Assembly extends React.Component {
         this.symptoms,
       ),
     )
+    
+    // Because we use survey date and time for both medication
+    // and side effect reports we need to reset here
+    this.survey_date = DateTime.local().setLocale(this.locale).toISODate();
+    this.survey_medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
+    this.survey_tookMedication = null
+    this.survey_notTakingMedicationReason = null
 
     this.survey_anySymptoms = null;
     this.symptoms = {

--- a/src/Assembly.js
+++ b/src/Assembly.js
@@ -355,9 +355,6 @@ class Assembly extends React.Component {
         </Observer>
       </Content>
 
-      {/* Temporarily deleting this to see how it effects the app */}
-      {/* <Space className="SPACE" /> */}
-
       <WhenAuthenticated account={this.participant_account} >
         <NavBar>
           <Navigation assembly={this} />

--- a/src/components/AdherenceCalendar.js
+++ b/src/components/AdherenceCalendar.js
@@ -12,6 +12,11 @@ const AdherenceCalendar = observer(({ assembly }) => (
   <Calendar
     locale={{ "Español": "es", "English": "en" }[assembly.language]}
     minDetail="year"
+
+    tileDisabled={({activeStartDate, date, view }) => {
+      return (DateTime.fromJSDate(date) > DateTime.local())}
+    }
+
     // Use https://moment.github.io/luxon/docs/manual/parsing.html#table-of-tokens
     // if you need to format the date again
     // React calendar returns this format of date "Fri Mar 29 2019 00:00:00 GMT-1000 (Hawaii-Aleutian Standard Time)"

--- a/src/components/AdherenceCalendar.js
+++ b/src/components/AdherenceCalendar.js
@@ -13,7 +13,7 @@ const AdherenceCalendar = observer(({ assembly }) => (
     locale={{ "Español": "es", "English": "en" }[assembly.language]}
     minDetail="year"
 
-    tileDisabled={({activeStartDate, date, view }) => {
+    tileDisabled={({date}) => {
       return (DateTime.fromJSDate(date) > DateTime.local())}
     }
 

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -38,8 +38,7 @@ const Contact = observer(({assembly}) => (
           {assembly.translate("contact.discussion_title")}
         </h3>
 
-        {/* TOOD: In the future we may not want the target to be blank */}
-        <Link href="https://asistente.trydiscourse.com/" target="_blank">
+        <Link href="https://tb-discourse.cirg.washington.edu" target="_blank">
           <Button backgroundColor={blue}>{assembly.translate("contact.discussion")}</Button>
         </Link>
       </div>

--- a/src/components/CoordinatorRegister.js
+++ b/src/components/CoordinatorRegister.js
@@ -35,6 +35,7 @@ const CoordinatorRegister = observer(({assembly}) => (
 
       <Field
         name="email"
+        // TODO: type can be email here?
         type="tel"
         value={assembly.coordinator_account.information.email || ""}
         onChange={(e) => assembly.coordinator_account.information.email = e.target.value}

--- a/src/components/CoordinatorRegister.js
+++ b/src/components/CoordinatorRegister.js
@@ -35,8 +35,7 @@ const CoordinatorRegister = observer(({assembly}) => (
 
       <Field
         name="email"
-        // TODO: type can be email here?
-        type="tel"
+        type="email"
         value={assembly.coordinator_account.information.email || ""}
         onChange={(e) => assembly.coordinator_account.information.email = e.target.value}
       />

--- a/src/components/Faqs.js
+++ b/src/components/Faqs.js
@@ -15,6 +15,7 @@ const FAQs = observer(({ assembly }) => (
 
     <P>{assembly.translate("faqs.intro_1")}</P>
     <P>{assembly.translate("faqs.intro_2")}</P>
+    <P><a href={assembly.translate("faqs.q1.answer.Link")} target="_blank">{assembly.translate("faqs.q1.answer.2")}</a></P>
 
     <Fold>
       <Question>
@@ -23,7 +24,6 @@ const FAQs = observer(({ assembly }) => (
 
       <Answer>
         <P>{assembly.translate("faqs.q1.answer.1")}</P>
-        <P><a href={assembly.translate("faqs.q1.answer.Link")} target="_blank">{assembly.translate("faqs.q1.answer.2")}</a></P>
         <P>{assembly.translate("faqs.q1.answer.3")}</P>
         <P>{assembly.translate("faqs.q1.answer.4")}</P>
         <P>{assembly.translate("faqs.q1.answer.5")}</P>

--- a/src/components/Faqs.js
+++ b/src/components/Faqs.js
@@ -15,7 +15,13 @@ const FAQs = observer(({ assembly }) => (
 
     <P>{assembly.translate("faqs.intro_1")}</P>
     <P>{assembly.translate("faqs.intro_2")}</P>
-    <P><a href={assembly.translate("faqs.q1.answer.Link")} target="_blank">{assembly.translate("faqs.q1.answer.2")}</a></P>
+    <P>
+      <a 
+        href={assembly.translate("faqs.q1.answer.Link")}
+        target="_blank">
+        {assembly.translate("faqs.q1.answer.2")}
+      </a>
+    </P>
 
     <Fold>
       <Question>

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -63,6 +63,4 @@ const Form = styled.div`
   grid-column-gap: 1rem;
 `
 
-// Temporarly deleting
-// Login.route = "/login"
 export default Login;

--- a/src/components/MedicationReports.js
+++ b/src/components/MedicationReports.js
@@ -30,6 +30,11 @@ const MedicationReports = observer(({ assembly }) => (
       .participant_account
       .information
       .medication_reports
+      .sort(function(a,b){
+        // Turn your strings into dates, and then subtract them
+        // to get a value that is either negative, positive, or zero.
+        return new Date(b.timestamp) - new Date(a.timestamp);
+      })
       .map(({timestamp, id, took_medication, not_taking_medication_reason}) => (
         // TODO: Sort by date and link reports
         <Answer>

--- a/src/components/MedicationReports.js
+++ b/src/components/MedicationReports.js
@@ -31,14 +31,16 @@ const MedicationReports = observer(({ assembly }) => (
       .information
       .medication_reports
       .sort(function(a,b){
-        // Turn your strings into dates, and then subtract them
-        // to get a value that is either negative, positive, or zero.
         return new Date(b.timestamp) - new Date(a.timestamp);
       })
       .map(({timestamp, id, took_medication, not_taking_medication_reason}) => (
-        // TODO: Sort by date and link reports
         <Answer>
-          <Time key={id}>{DateTime.fromISO(timestamp).toLocaleString(DateTime.DATETIME_SHORT)}</Time>
+          <Time key={id}>
+            {DateTime
+              .fromISO(timestamp, {zone: 'utc'})
+              .setLocale(assembly.locale)
+              .toLocaleString(DateTime.DATETIME_SHORT)}
+          </Time>
 
           <Info key={took_medication}>
             {assembly.translate("progress.took_medication")}

--- a/src/components/MedicationReports.js
+++ b/src/components/MedicationReports.js
@@ -30,8 +30,9 @@ const MedicationReports = observer(({ assembly }) => (
       .participant_account
       .information
       .medication_reports
+      .slice()
       .sort(function(a,b){
-        return new Date(b.timestamp) - new Date(a.timestamp);
+        return DateTime.fromISO(b.timestamp) - DateTime.fromISO(a.timestamp);
       })
       .map(({timestamp, id, took_medication, not_taking_medication_reason}) => (
         <Answer>

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -18,7 +18,7 @@ const Progress = observer(({ assembly }) => (
         <div>
           <h2>{assembly.translate("progress.title")}</h2>
         <ProgressBarContainer>
-          <TreatmentProgress>
+          <TreatmentProgress assembly={assembly}>
             <Percentage>{days_of_treatment(assembly.participant_account.information)}</Percentage>
 
             <TreatmentDays>

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -9,6 +9,7 @@ import { white, grey } from "../colors"
 import InternalLink from "../primitives/InternalLink"
 import Login from "./Login"
 import CoordinatorLogin from "./CoordinatorLogin"
+import InputMask from "react-input-mask"
 
 const Register = observer(({assembly}) => (
   <Layout>
@@ -31,11 +32,25 @@ const Register = observer(({assembly}) => (
         {assembly.translate("register.phone_number")}
       </label>
 
+      <FieldDiv>
+        <InputMask 
+          mask="+5\4 99 9999 9999" 
+          maskChar={null} 
+          name="phone_number"
+          type="tel"
+          value={assembly.participant_account.information.phone_number || ""}
+          onChange={(e) => assembly.participant_account.information.phone_number = e.target.value}
+        />
+      </FieldDiv>
+
+      <label htmlFor="phone_number">
+        {assembly.translate("register.email")}
+      </label>
+
       <Field
-        name="phone_number"
-        type="tel"
-        value={assembly.participant_account.information.phone_number || ""}
-        onChange={(e) => assembly.participant_account.information.phone_number = e.target.value}
+        type="email"
+        value={assembly.participant_account.information.email || ""}
+        onChange={(e) => assembly.participant_account.information.email = e.target.value}
       />
 
       <label htmlFor="treatment_start">
@@ -79,7 +94,15 @@ const Layout = styled(ListOfLinks)`
 const Field = styled(Input)`
   background-color: ${white}
   padding: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
+  border-radius: 2px;
+  border: 1px solid ${grey};
+`
+
+const FieldDiv = styled.div`
+  background-color: ${white}
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
   border-radius: 2px;
   border: 1px solid ${grey};
 `

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -32,16 +32,23 @@ const Register = observer(({assembly}) => (
         {assembly.translate("register.phone_number")}
       </label>
 
-      <FieldDiv>
+      <Field
+        name="phone_number"
+        type="tel"
+        value={assembly.participant_account.information.phone_number || ""}
+        onChange={(e) => assembly.participant_account.information.phone_number = e.target.value}
+      />
+
+      {/* <FieldDiv>
         <InputMask 
-          mask="+5\4 99 9999 9999" 
+          mask="5\4 099 9999 9999"
           maskChar={null} 
           name="phone_number"
           type="tel"
           value={assembly.participant_account.information.phone_number || ""}
           onChange={(e) => assembly.participant_account.information.phone_number = e.target.value}
         />
-      </FieldDiv>
+      </FieldDiv> */}
 
       <label htmlFor="treatment_start">
         {assembly.translate("register.treatment_start")}

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -43,16 +43,6 @@ const Register = observer(({assembly}) => (
         />
       </FieldDiv>
 
-      <label htmlFor="phone_number">
-        {assembly.translate("register.email")}
-      </label>
-
-      <Field
-        type="email"
-        value={assembly.participant_account.information.email || ""}
-        onChange={(e) => assembly.participant_account.information.email = e.target.value}
-      />
-
       <label htmlFor="treatment_start">
         {assembly.translate("register.treatment_start")}
       </label>

--- a/src/components/ReportMedication.js
+++ b/src/components/ReportMedication.js
@@ -13,7 +13,6 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportMedication = observer(({ assembly }) => (
   <Layout>
-    {/* TODO: If the current date is today then use "today" */}
     <Heading>{assembly.translate("survey.tookMedication.title") + assembly.survey_date + "?"}</Heading>
 
     <Selection

--- a/src/components/ReportMedication.js
+++ b/src/components/ReportMedication.js
@@ -13,7 +13,8 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportMedication = observer(({ assembly }) => (
   <Layout>
-    <Heading>{assembly.translate("survey.tookMedication.title") + assembly.survey_date}</Heading>
+    {/* TODO: If the current date is today then use "today" */}
+    <Heading>{assembly.translate("survey.tookMedication.title") + assembly.survey_date + "?"}</Heading>
 
     <Selection
       update={() =>

--- a/src/components/ReportMedication.js
+++ b/src/components/ReportMedication.js
@@ -13,7 +13,10 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportMedication = observer(({ assembly }) => (
   <Layout>
-    <Heading>{assembly.translate("survey.tookMedication.title") + assembly.survey_date + "?"}</Heading>
+    <Heading>
+      {assembly.translate("survey.tookMedication.title")}
+      {assembly.survey_date + "?"}
+    </Heading>
 
     <Selection
       update={() =>

--- a/src/components/ReportSymptoms.js
+++ b/src/components/ReportSymptoms.js
@@ -26,7 +26,7 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportSymptoms = observer(({ assembly, survey }) => (
   <Layout>
-    <Heading>{assembly.translate("survey.symptoms.title")}</Heading>
+    <Heading>{assembly.translate("survey.symptoms.title") + assembly.survey_date + "?"}</Heading>
 
     <Selection
       update={() =>

--- a/src/components/ReportSymptoms.js
+++ b/src/components/ReportSymptoms.js
@@ -26,7 +26,10 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportSymptoms = observer(({ assembly, survey }) => (
   <Layout>
-    <Heading>{assembly.translate("survey.symptoms.title") + assembly.survey_date + "?"}</Heading>
+    <Heading>
+      {assembly.translate("survey.symptoms.title")}
+      {assembly.survey_date + "?"}
+    </Heading>
 
     <Selection
       update={() =>

--- a/src/components/ReportSymptoms.js
+++ b/src/components/ReportSymptoms.js
@@ -148,7 +148,7 @@ const ReportSymptoms = observer(({ assembly, survey }) => (
           checked={assembly.symptoms.sore_belly}
           onChange={(e) => assembly.symptoms.sore_belly = e.target.checked}
         />
-        <span>{assembly.translate("survey.symptoms.upset_stomach")}</span>
+        <span>{assembly.translate("survey.symptoms.sore_belly")}</span>
       </Label>
 
       <Label>

--- a/src/components/SideEffects.js
+++ b/src/components/SideEffects.js
@@ -30,7 +30,7 @@ const SideEffects = observer(({ assembly }) => (
             .information.symptom_reports
             .slice()
             .sort(function(a,b){
-              return new Date(b.timestamp) - new Date(a.timestamp);
+              return DateTime.fromISO(b.timestamp) - DateTime.fromISO(a.timestamp);
             })
             .map((sr) => (
           <Answer key={sr.created_at}>
@@ -45,12 +45,15 @@ const SideEffects = observer(({ assembly }) => (
             { sr.reported_symptoms.length !== 0
 
             ? <Info>
-                { sr
+                {sr
                   .reported_symptoms
-                  .map(symptom_key => assembly.translate(`survey.symptoms.${symptom_key}`))
-                  .join(",")}
-
-                { sr.nausea_rating }
+                  .map(symptom_key => (
+                    <span>
+                      {assembly.translate(`survey.symptoms.${symptom_key}`)}
+                    </span>
+                  ))
+                }
+                { sr.nausea_rating ? sr.nausea_rating : null }
                 { sr.other }
               </Info>
 

--- a/src/components/SideEffects.js
+++ b/src/components/SideEffects.js
@@ -28,17 +28,16 @@ const SideEffects = observer(({ assembly }) => (
         : assembly
             .participant_account
             .information.symptom_reports
-            .slice().sort(function(a,b){
-              // Turn your strings into dates, and then subtract them
-              // to get a value that is either negative, positive, or zero.
-              return new Date(b.created_at) - new Date(a.created_at);
+            .slice()
+            .sort(function(a,b){
+              return new Date(b.timestamp) - new Date(a.timestamp);
             })
             .map((sr) => (
-          // TODO: Sort by date and link reports
           <Answer key={sr.created_at}>
             <Time>
               { DateTime
-                .fromISO(sr.created_at)
+                .fromISO(sr.timestamp, {zone: 'utc'})
+                .setLocale(assembly.locale)
                 .toLocaleString(DateTime.DATETIME_SHORT)
               }
             </Time>

--- a/src/components/SideEffects.js
+++ b/src/components/SideEffects.js
@@ -25,7 +25,15 @@ const SideEffects = observer(({ assembly }) => (
             <Info>{assembly.translate("progress.no_side_effects")}</Info>
           </Answer>
 
-        : assembly.participant_account.information.symptom_reports.map((sr) => (
+        : assembly
+            .participant_account
+            .information.symptom_reports
+            .slice().sort(function(a,b){
+              // Turn your strings into dates, and then subtract them
+              // to get a value that is either negative, positive, or zero.
+              return new Date(b.created_at) - new Date(a.created_at);
+            })
+            .map((sr) => (
           // TODO: Sort by date and link reports
           <Answer key={sr.created_at}>
             <Time>

--- a/src/components/SideEffects.js
+++ b/src/components/SideEffects.js
@@ -41,7 +41,7 @@ const SideEffects = observer(({ assembly }) => (
                 { sr
                   .reported_symptoms
                   .map(symptom_key => assembly.translate(`survey.symptoms.${symptom_key}`))
-                  .join(", ")}
+                  .join(",")}
 
                 { sr.nausea_rating }
                 { sr.other }

--- a/src/components/StripReports.js
+++ b/src/components/StripReports.js
@@ -28,15 +28,17 @@ const StripReports = observer(({ assembly }) => (
             : assembly
                 .participant_account
                 .information.strip_reports
+                .slice()
                 .sort(function(a,b){
-                  // Turn your strings into dates, and then subtract them
-                  // to get a value that is either negative, positive, or zero.
-                  return new Date(a.created_at) - new Date(b.created_at);
+                  return new Date(b.created_at) - new Date(a.created_at);
                 })
                 .map(({created_at, photo, status}) => (
               <Answer>
                 <Time key={created_at}>
-                  {DateTime.fromISO(created_at).toLocaleString(DateTime.DATETIME_SHORT)}
+                  {DateTime
+                    .fromISO(created_at)
+                    .setLocale(assembly.locale)
+                    .toLocaleString(DateTime.DATETIME_SHORT)}
                 </Time>
                 <Info>
                   {status || assembly.translate("progress.not_reviewed")}

--- a/src/components/StripReports.js
+++ b/src/components/StripReports.js
@@ -30,7 +30,8 @@ const StripReports = observer(({ assembly }) => (
                 .information.strip_reports
                 .slice()
                 .sort(function(a,b){
-                  return new Date(b.created_at) - new Date(a.created_at);
+                  // NOTE: We are using created_at here, which is when rails captured the photo
+                  return DateTime.fromISO(b.created_at) - DateTime.fromISO(a.created_at);
                 })
                 .map(({created_at, photo, status}) => (
               <Answer>

--- a/src/components/StripReports.js
+++ b/src/components/StripReports.js
@@ -25,7 +25,15 @@ const StripReports = observer(({ assembly }) => (
                 <Info>{assembly.translate("progress.no_strip_reports")}</Info>
               </Answer>
 
-            : assembly.participant_account.information.strip_reports.map(({created_at, photo, status}) => (
+            : assembly
+                .participant_account
+                .information.strip_reports
+                .sort(function(a,b){
+                  // Turn your strings into dates, and then subtract them
+                  // to get a value that is either negative, positive, or zero.
+                  return new Date(a.created_at) - new Date(b.created_at);
+                })
+                .map(({created_at, photo, status}) => (
               <Answer>
                 <Time key={created_at}>
                   {DateTime.fromISO(created_at).toLocaleString(DateTime.DATETIME_SHORT)}

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -142,7 +142,7 @@ export default {
       `,
 
       title: `
-      Did you experience any side effects after taking the medication on 
+      Did you experience any side effects after taking the medication?
       `,
 
       yes: `

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -142,7 +142,7 @@ export default {
       `,
 
       title: `
-      Did you experience any side effects after taking the medication?
+      Did you experience any side effects after taking the medication on 
       `,
 
       yes: `

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -649,7 +649,7 @@ export default {
         `,
 
         2: `
-        Link to educational video
+        Link for an educational video
         `,
 
         Link: `

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -117,7 +117,7 @@ export default {
       Blurred vision or changes in the way you see colors
       `,
 
-      upset_stomach: `
+      sore_belly: `
       Upset stomach
       `,
 
@@ -307,6 +307,10 @@ export default {
 
     phone_number: `
     Phone Number
+    `,
+
+    email: `
+    Email
     `,
 
     language: `

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -115,7 +115,7 @@ export default {
       Visión borrosa o cambios en la forma de ver los colores
       `,
 
-      upset_stomach: `
+      sore_belly: `
       Dolor de barriga
       `,
 
@@ -252,6 +252,10 @@ export default {
     Número de teléfono
     `,
 
+    email: `
+    Correo electrónico
+    `,
+
     study_id: `
     studyID
     `,
@@ -285,7 +289,7 @@ export default {
     `,
 
     email: `
-    Email
+    Correo electrónico
     `,
 
     password: "Contraseña",
@@ -358,7 +362,7 @@ export default {
     `,
 
     days: `
-    Número de días en tratamiento
+    Días en tratamiento
     `,
 
     medication: `
@@ -1256,7 +1260,7 @@ export default {
   coordinator_login: {
     welcome: "Bienvenido",
     context: "Iniciar sesión para asistente de tratamiento",
-    email: "correo electrónico",
+    email: "Correo electrónico",
     password: "Contraseña",
     go: "Iniciar sesión",
 

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -53,12 +53,14 @@ export default {
       No
       `,
 
+      // TODO: If it is the current date then say,
+      // Did you take your medication today?
       // title: `
       // ¿Tomaste los medicamentos hoy?
       // `,
 
       title: `
-      Did you take your medication on
+      ¿Tomaste los medicamentos el dia
       `,
 
       reason: `
@@ -140,7 +142,7 @@ export default {
       `,
 
       title: `
-      ¿Presentaste algún  malestar al tomar los remedios?
+      ¿Presentaste algún malestar al tomar los remedios el dia 
       `,
 
       yes: `
@@ -352,7 +354,7 @@ export default {
     `,
 
     discussion: `
-    Link to Discussion Forum (es)
+    Enlace a foro de discusión
     `,
   },
 

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -370,7 +370,7 @@ export default {
     `,
 
     side_effect: `
-    Efectos adversos o indeseables
+    Efectos adversos
     `,
 
     test_result: `
@@ -394,7 +394,7 @@ export default {
     `,
 
     took_medication: `
-    control de medicación
+    Control de medicación:
     `,
 
     took_medication_yes: `
@@ -661,7 +661,7 @@ export default {
         `,
 
         2: `
-        Link to educational video (es)
+        Enlace a un video educativo
         `,
 
         Link: `

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -254,10 +254,6 @@ export default {
     Número de teléfono
     `,
 
-    email: `
-    Correo electrónico
-    `,
-
     study_id: `
     studyID
     `,
@@ -290,11 +286,9 @@ export default {
     Nombre
     `,
 
-    email: `
-    Correo electrónico
+    password: `
+    Contraseña
     `,
-
-    password: "Contraseña",
 
     register: `
     Registrarse

--- a/src/primitives/TreatmentProgress.js
+++ b/src/primitives/TreatmentProgress.js
@@ -9,7 +9,7 @@ import days_of_treatment from "../util/days_of_treatment"
 const TreatmentProgress = observer(({ children, assembly }) => (
     <Layout>
       <Progressbar        
-        percentage={days_of_treatment(assembly.participant_account.information) / 180}
+        percentage={days_of_treatment(assembly.participant_account.information) / 180 * 100}
         styles={{ path: { stroke: primary } }}
       />
 

--- a/src/primitives/TreatmentProgress.js
+++ b/src/primitives/TreatmentProgress.js
@@ -4,11 +4,12 @@ import { observer } from "mobx-react"
 
 import CircularProgressbar from "react-circular-progressbar"
 import { primary } from "../colors"
+import days_of_treatment from "../util/days_of_treatment"
 
-const TreatmentProgress = observer(({ children }) => (
+const TreatmentProgress = observer(({ children, assembly }) => (
     <Layout>
-      <Progressbar
-        percentage={68}
+      <Progressbar        
+        percentage={days_of_treatment(assembly.participant_account.information) / 180}
         styles={{ path: { stroke: primary } }}
       />
 

--- a/src/util/days_of_treatment.js
+++ b/src/util/days_of_treatment.js
@@ -8,13 +8,13 @@ const days_of_treatment = (participant) => {
   
     // Goes through medication reports and grabs dates and only
     // reports where they indicate they did take their medication
-    debugger
+    // debugger
     // let all_true_reports = participant.medication_reports.map(report => {
     //   if (report.took_medication === true) {
     //     return report;
     //   }};
     
-    let report_dates = all_true_reports.map(report =>
+    let report_dates = participant.medication_reports.map(report =>
       DateTime.fromISO(report.timestamp).toISODate()
     )
   

--- a/src/util/days_of_treatment.js
+++ b/src/util/days_of_treatment.js
@@ -5,14 +5,6 @@ const days_of_treatment = (participant) => {
     let end = DateTime.local()
     let full_days = parseInt(end.diff(start, 'days').toObject().days, 10)
     if(full_days === 0) full_days = 1
-  
-    // Goes through medication reports and grabs dates and only
-    // reports where they indicate they did take their medication
-    // debugger
-    // let all_true_reports = participant.medication_reports.map(report => {
-    //   if (report.took_medication === true) {
-    //     return report;
-    //   }};
     
     let report_dates = participant.medication_reports.map(report =>
       DateTime.fromISO(report.timestamp).toISODate()

--- a/src/util/days_of_treatment.js
+++ b/src/util/days_of_treatment.js
@@ -6,7 +6,15 @@ const days_of_treatment = (participant) => {
     let full_days = parseInt(end.diff(start, 'days').toObject().days, 10)
     if(full_days === 0) full_days = 1
   
-    let report_dates = participant.medication_reports.map(report =>
+    // Goes through medication reports and grabs dates and only
+    // reports where they indicate they did take their medication
+    debugger
+    // let all_true_reports = participant.medication_reports.map(report => {
+    //   if (report.took_medication === true) {
+    //     return report;
+    //   }};
+    
+    let report_dates = all_true_reports.map(report =>
       DateTime.fromISO(report.timestamp).toISODate()
     )
   


### PR DESCRIPTION
My progress now sorts by date, and uses `timestamp` for MedicationReports and SideEffects, but uses `created_at` for StripReports

Dates are also all using .setLocale for proper Spanish formatting.