### PR TITLE
Addressed April 2 feedback

### DIFF
--- a/src/components/AdherenceCalendar.js
+++ b/src/components/AdherenceCalendar.js
@@ -21,7 +21,10 @@ const AdherenceCalendar = observer(({ assembly }) => (
     // if you need to format the date again
     // React calendar returns this format of date "Fri Mar 29 2019 00:00:00 GMT-1000 (Hawaii-Aleutian Standard Time)"
     onClickDay={((value) => assembly.survey_date =
-                           DateTime.fromFormat(value.toString().substr(0, 15), 'EEE LLL dd yyyy').toISODate())}
+                           DateTime
+                            .fromFormat(value.toString().substr(0, 15), 'EEE LLL dd yyyy')
+                            .setLocale(assembly.locale)
+                            .toLocaleString(DateTime.DATE_SHORT))}
 
     onChange={() => assembly.currentPage = Survey}
 

--- a/src/components/CoordinatorHome.js
+++ b/src/components/CoordinatorHome.js
@@ -74,7 +74,6 @@ const CoordinatorHome = observer(({ assembly }) => (
         .map(participant =>
         <Row
           key={participant.uuid}
-          onClick={() => assembly.participant_history.watch(participant.uuid, () => assembly.currentPage = CoordinatorParticipantHistory)}
         >
           <Cell>
             { participant_has_reports_that_have_not_been_resolved(participant)
@@ -103,13 +102,16 @@ const CoordinatorHome = observer(({ assembly }) => (
             }
           </Cell>
 
-          <Cell>{participant.name}</Cell>
+          <NameLinkCell onClick={() => assembly.participant_history.watch(participant.uuid, () => assembly.currentPage = CoordinatorParticipantHistory)}>
+            {participant.name}
+          </NameLinkCell>
 
           <Cell>
             { participant.today.medication_reports.length > 0
               ? DateTime
-                .fromISO(participant.today.medication_reports[0].timestamp)
-                .toLocaleString(DateTime.TIME_SIMPLE)
+                  .fromISO(participant.today.medication_reports[0].timestamp, {zone: 'utc'})
+                  .setLocale(assembly.locale)
+                  .toLocaleString(DateTime.TIME_SIMPLE)
               : null
             }
           </Cell>
@@ -118,7 +120,8 @@ const CoordinatorHome = observer(({ assembly }) => (
             {participant.today.symptom_reports.map(symptom_report =>
               <div key={symptom_report.created_at} >
                 { DateTime
-                    .fromISO(symptom_report.created_at)
+                    .fromISO(symptom_report.timestamp, {zone: 'utc'})
+                    .setLocale(assembly.locale)
                     .toLocaleString(DateTime.TIME_SIMPLE)
                 }
                 { symptom_report.reported_symptoms.map(symptom =>
@@ -142,7 +145,7 @@ const CoordinatorHome = observer(({ assembly }) => (
           </Cell>
 
           <Cell>
-            <a href={'https://wa.me/' + participant.phone_number} target="_blank">
+            <a href={'https://wa.me/' + participant.phone_number.replace(/-/g, "")} target="_blank">
               {participant.phone_number}
             </a>
           </Cell>
@@ -213,6 +216,11 @@ const Row = styled.div`
 
 const Cell = styled.div`
   padding: 0.5rem;
+`
+
+const NameLinkCell = styled.div`
+  padding: 0.5rem;
+  text-decoration: underline;
 `
 
 // Need a thorough review of this logic;

--- a/src/components/CoordinatorParticipantHistory.js
+++ b/src/components/CoordinatorParticipantHistory.js
@@ -79,6 +79,9 @@ const CoordinatorParticipantHistory = observer(({ assembly }) => (
               {assembly.translate("coordinator_participant_history.medication")}
             </th>
             <th>
+              {assembly.translate("coordinator_participant_history.medication_taken")}
+            </th>
+            <th>
               {assembly.translate("coordinator_participant_history.side_effects")}
             </th>
             <th>
@@ -101,12 +104,16 @@ const CoordinatorParticipantHistory = observer(({ assembly }) => (
               .medication_reports
             || []
             )
+            .slice()
+            .sort(function(a,b){
+              return DateTime.fromISO(b.timestamp) - DateTime.fromISO(a.timestamp);
+            })
             .map(mr =>
               <tr key={mr.timestamp}>
                 <td>
                   <Padding>
                     { DateTime
-                      .fromISO(mr.timestamp)
+                      .fromISO(mr.timestamp, {zone: 'utc'})
                       .setLocale(assembly.locale)
                       .toLocaleString(DateTime.DATE_SIMPLE)
                     }
@@ -114,9 +121,19 @@ const CoordinatorParticipantHistory = observer(({ assembly }) => (
 
                   <Padding>
                     { DateTime
-                      .fromISO(mr.timestamp)
+                      .fromISO(mr.timestamp, {zone: 'utc'})
                       .setLocale(assembly.locale)
                       .toLocaleString(DateTime.TIME_SIMPLE)
+                    }
+                  </Padding>
+                </td>
+                
+                <td>
+                  <Padding>
+                    { mr.took_medication
+                    ? assembly.translate("progress.took_medication_yes")
+                    : assembly.translate("progress.took_medication_no") +
+                      mr.not_taking_medication_reason
                     }
                   </Padding>
                 </td>

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -31,11 +31,15 @@ const Register = observer(({assembly}) => (
       <label htmlFor="phone_number">
         {assembly.translate("register.phone_number")}
       </label>
+      
+      <label>
+        {"54-911-0000-2222"}
+      </label>
 
       <Field
         name="phone_number"
         type="tel"
-        value={assembly.participant_account.information.phone_number || ""}
+        value={assembly.participant_account.information.phone_number || "54-911"}
         onChange={(e) => assembly.participant_account.information.phone_number = e.target.value}
       />
 

--- a/src/components/ReportSymptoms.js
+++ b/src/components/ReportSymptoms.js
@@ -4,6 +4,7 @@ import { observer } from "mobx-react"
 import { Hidden, Input, Provider, Popover } from "reakit"
 import { darkgrey, grey, white } from "../colors"
 import theme from "reakit-theme-default";
+import { DateTime } from "luxon"
 
 import hives from "../images/hives.jpg"
 import rash from "../images/rash.jpg"
@@ -25,9 +26,12 @@ const translation_keys =  { true: "yes", false: "no" }
 
 const ReportSymptoms = observer(({ assembly, survey }) => (
   <Layout>
+
     <Heading>
       {assembly.translate("survey.symptoms.title")}
-      {assembly.survey_date + "?"}
+      {assembly.survey_date == DateTime.local().setLocale(assembly.locale).toLocaleString()
+        ? assembly.translate("survey.symptoms.today")
+        : assembly.translate("survey.symptoms.on") + assembly.survey_date + "?"}
     </Heading>
 
     <Selection

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -145,7 +145,19 @@ export default {
       `,
 
       title: `
-      ¿Presentaste algún malestar al tomar los remedios hoy
+      ¿Presentaste algún malestar al tomar los remedios
+      `,
+
+      today: `
+      hoy?
+      `,
+
+      on: `
+      el dia
+      `,
+
+      on: `
+      hoy?
       `,
 
       yes: `
@@ -1144,6 +1156,7 @@ export default {
     name: "Nombre",
     today: "Hoy",
     medication: "Control de la medicación",
+    medication_taken: "Control de la medicacion",
     side_effects: "Efectos adversos o indeseables",
     photo: "Resultados del test de orina",
     actions: "Acción",


### PR DESCRIPTION
- hoy for side effects page, now when you click on todays date it says hoy not todays date
- dolor de la panza, for side effects
- 2019-04-01, Datetime not in the right format when you click on a date on the calendar, should be Day/Month/Year
- Add formatting of the phone number to the registration page, also trims ("-") from the phone number on the coordinator page
- whole row should not be clickable, the name of the patient should be clickable on CoordinatorHome
- medication time differs from side effect time
- added sorting to coordinator patient history page
- added the took_medication field to the patient history page