### PR TITLE
Null error on patient and history bug on coordinator side

### DIFF
--- a/src/Account.js
+++ b/src/Account.js
@@ -39,7 +39,7 @@ class Account {
       response
         .json()
         .then(r => this.information = r)
-        .then(() => { if(callback) callback() })
+        .then(() => { if(callback) callback();})
         .catch(e => console.log(e))
     })
   }

--- a/src/Assembly.js
+++ b/src/Assembly.js
@@ -153,6 +153,16 @@ class Assembly extends React.Component {
         this.alert(this.translate("symptom_overview.take_action_immediately"))
     })
 
+    // This solution fixes a redirect error. Prior, it saved a network watch
+    // request for the participants history and would go to the history page
+    // Now we ditch the network watch when we had to a history page.
+    // This has not been thoroughly tested for regression yet.
+    autorun(() => {
+      if (this.currentPage === CoordinatorParticipantHistory)
+        network.clearLast();
+    })
+
+    // Every 5 minutes refresh the coordinator home
     autorun(() => {
       if(this.currentPage === CoordinatorHome)
         this.coordinator_timer = setInterval(
@@ -165,8 +175,8 @@ class Assembly extends React.Component {
       }
     })
 
-    this.survey_date = DateTime.local().setLocale(this.locale).toLocaleString()
-    this.survey_medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
+    this.survey.date = DateTime.local().setLocale(this.locale).toLocaleString()
+    this.survey.medication_time = DateTime.local().setLocale(this.locale).toLocaleString(DateTime.TIME_24_SIMPLE)
 
     // When the page loads,
     // immediately look for stored credentials in `localStorage`.

--- a/src/Network.js
+++ b/src/Network.js
@@ -23,7 +23,6 @@ class Network {
       }).then(resolve)
     }).then((result) => {
       this.refresh()
-
       return result;
     })
   }
@@ -53,6 +52,10 @@ class Network {
 
   clearWatches() {
     this.watches = []
+  }
+
+  clearLast() {
+    this.watches.pop();
   }
 
   destruct() {

--- a/src/components/CoordinatorHome.js
+++ b/src/components/CoordinatorHome.js
@@ -106,17 +106,15 @@ const CoordinatorHome = observer(({ assembly }) => (
                       </CoordinatorNote>
 
                       <span onClick={(e) => {
-                        e.stopPropagation()
-                        e.preventDefault()
                         assembly.resolve_participant_records(participant, "reviewed")
+                        e.stopPropagation()
                       }} >
                         {Icons.reviewed}
                       </span>
 
                       <span onClick={(e) => {
-                        e.stopPropagation()
-                        e.preventDefault()
                         assembly.resolve_participant_records(participant, "overdue")
+                        e.stopPropagation()
                       }} >
                         {Icons.overdue}
                       </span>

--- a/src/components/CoordinatorHome.js
+++ b/src/components/CoordinatorHome.js
@@ -100,21 +100,23 @@ const CoordinatorHome = observer(({ assembly }) => (
                   </Popover.Toggle>
 
                   <Popover hideOnClickOutside {...popover} >
-                    <Card onClick={(e) => { e.stopPropagation(); e.preventDefault() }} >
+                    <Card onClick={(e) => { e.stopPropagation(); e.preventDefault(); }} >
                       <CoordinatorNote>
                         {field(assembly, `coordinator_note.${participant.uuid}`, "textarea").field}
                       </CoordinatorNote>
 
                       <span onClick={(e) => {
-                        assembly.resolve_participant_records(participant, "reviewed")
                         e.stopPropagation()
+                        e.preventDefault()
+                        assembly.resolve_participant_records(participant, "reviewed")
                       }} >
                         {Icons.reviewed}
                       </span>
 
                       <span onClick={(e) => {
-                        assembly.resolve_participant_records(participant, "overdue")
                         e.stopPropagation()
+                        e.preventDefault()
+                        assembly.resolve_participant_records(participant, "overdue")
                       }} >
                         {Icons.overdue}
                       </span>
@@ -143,11 +145,13 @@ const CoordinatorHome = observer(({ assembly }) => (
           </div>
 
           <NameLinkCell
-            onClick={() =>
+            className="NameLinkCell"
+            onClick={(e) => {
               assembly.participant_history.watch(
                 participant.uuid,
                 () => assembly.currentPage = CoordinatorParticipantHistory
               )
+              }
             }>
             {participant.name}
           </NameLinkCell>
@@ -279,6 +283,7 @@ const Cell = styled.div`
 const NameLinkCell = styled.div`
   padding: 0.5rem;
   text-decoration: underline;
+  cursor: pointer;
 `
 
 const Status = styled(InlineBlock)`

--- a/src/components/CoordinatorParticipantHistory.js
+++ b/src/components/CoordinatorParticipantHistory.js
@@ -147,6 +147,12 @@ const CoordinatorParticipantHistory = observer(({ assembly }) => (
                         <PhotoPopout src={report.photo} key={report.id} />
 
                         <Padding>
+                          { DateTime
+                              .fromISO(report.created_at)
+                              .setLocale(assembly.locale)
+                              .toLocaleString(DateTime.DATETIME_SHORT)
+                          }
+                          <br></br>
                           {report.status}
                         </Padding>
                       </div>


### PR DESCRIPTION
Addresses the null error when a patient was clicking track treatment or today's date.

Addresses the error when a coordinator clicked on a test strip or icon and was taken to a different patients history page