### PR TITLE
Add matomo custom variable to track launch from browser or standalone

### DIFF
--- a/src/Patient/Home/Education/index.js
+++ b/src/Patient/Home/Education/index.js
@@ -2,12 +2,10 @@ import PopUp from '../../Navigation/PopUp'
 import React, { useEffect, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles';
 import Styles from '../../../Basics/Styles';
-import Colors from '../../../Basics/Colors';
 import { observer } from 'mobx-react';
 import useStores from '../../../Basics/UseStores';
 import { useTranslation } from 'react-i18next';
 import { usePageVisibility } from '../../../Hooks/PageVisibility'
-import ForumIcon from '@material-ui/icons/Forum';
 import TestStripUpdate from './TestStripUpdateMay'
 import ChatReminder from './ChatReminder';
 import DefaultLayout from './DefaultMessage'
@@ -30,7 +28,6 @@ const EducationalMessage = observer((props) => {
     const { educationStore: education } = patientStore;
 
     const isVisible = usePageVisibility();
-
 
     //Check for service worker update when page goes from invisible to visible.
     //this helps us detect when the application is launched from installed

--- a/src/Patient/index.js
+++ b/src/Patient/index.js
@@ -15,6 +15,7 @@ import { useMatomo } from '@datapunt/matomo-tracker-react'
 import ErrorListener from './ErrorListener';
 import ForcePasswordChange from './ForcePasswordChange';
 import EducationalMessage from './Home/Education';
+import { usePageVisibility } from '../Hooks/PageVisibility';
 
 const PatientHome = observer((props) => {
 
@@ -22,6 +23,7 @@ const PatientHome = observer((props) => {
   const tabs = [<Home />, <Progress />, <Messaging />, <Info />];
   const routeTab = tabs[patientUIStore.tabNumber]
   const { trackPageView, pushInstruction } = useMatomo();
+  const isVisible = usePageVisibility();
 
   // When tab is changed, make sure that we scroll to the top so user does not get lost
   // Track page view in Matomo
@@ -49,6 +51,18 @@ const PatientHome = observer((props) => {
       })
     }
   }, [uiStore.offline, dailyReportStore.numberOfflineReports])
+
+  useEffect(() => {
+    if (isVisible) {
+      let displayMode = 'browser';
+      const mqStandAlone = '(display-mode: standalone)';
+      if (navigator.standalone || window.matchMedia(mqStandAlone).matches) {
+        displayMode = 'standalone';
+      }
+      pushInstruction('setCustomVariable', 2, "clientLaunchType", displayMode, "visit");
+    }
+  }, [isVisible])
+
 
 
   if (patientStore.hasForcedPasswordChange) {


### PR DESCRIPTION
Tracks if the app was launched in standalone mode ( from homescreen without browser UI ) or if it was accessed from the browser only 