### PR TITLE
Apply subtitle styles to custom subtitles in messaging preview

### DIFF
--- a/src/Messaging/ChannelPreview.js
+++ b/src/Messaging/ChannelPreview.js
@@ -41,7 +41,7 @@ const ChannelPreview = observer((props) => {
     const getSubtitle = () => {
         if (props.private) return <Subtitle>{t("messaging.privateExplained")}</Subtitle>
         if (props.isSiteChannel) return <Subtitle>{t("messaging.clinicChat")}</Subtitle>
-        return props.subtitle
+        return <Subtitle>{props.subtitle}</Subtitle>
     }
 
     return (


### PR DESCRIPTION
Quick fix to channel preview. Previous refactor forgot to apply styles to custom messages that are not the default.