### PR TITLE
Fix/remove dot from pract tab

### DIFF
--- a/src/Practitioner/ReviewPatients/Tabs.js
+++ b/src/Practitioner/ReviewPatients/Tabs.js
@@ -76,33 +76,21 @@ const ReviewPatientTabs = ({ value }) => {
           className={classes.tab}
           component={Link}
           to="/home/needs-review"
-          label={
-            <LabelWithDot
-              text={t("reviewIssues.issues")}
-              color={Colors.yellow}
-            />
-          }
+          label={<LabelWithoutDot text={t("reviewIssues.issues")} />}
           {...a11yProps(0)}
         />
         <Tab
           className={classes.tab}
           component={Link}
           to="/home/reviewed"
-          label={
-            <LabelWithDot
-              text={t("reviewIssues.reviewed")}
-              color={Colors.green}
-            />
-          }
+          label={<LabelWithoutDot text={t("reviewIssues.reviewed")} />}
           {...a11yProps(1)}
         />
         <Tab
           className={classes.tab}
           component={Link}
           to="/home/all"
-          label={
-            <LabelWithDot text={t("time.all")} color={Colors.buttonBlue} />
-          }
+          label={<LabelWithoutDot text={t("time.all")} />}
           {...a11yProps(1)}
         />
       </Tabs>
@@ -110,12 +98,10 @@ const ReviewPatientTabs = ({ value }) => {
   );
 };
 
-const LabelWithDot = ({ text, color }) => {
-  const classes = useStyles({ color: color });
+const LabelWithoutDot = ({ text }) => {
   return (
     <Grid justify="center" direction="column" alignItems="center" container>
-      <FiberManualRecord className={classes.label} />
-      <Typography variant="body2">{text}</Typography>
+      <Typography variant="h6">{text}</Typography>
     </Grid>
   );
 };

--- a/src/Practitioner/ReviewPatients/Tabs.js
+++ b/src/Practitioner/ReviewPatients/Tabs.js
@@ -101,7 +101,7 @@ const ReviewPatientTabs = ({ value }) => {
 const LabelWithoutDot = ({ text }) => {
   return (
     <Grid justify="center" direction="column" alignItems="center" container>
-      <Typography variant="h6">{text}</Typography>
+      <Typography variant="body1">{text}</Typography>
     </Grid>
   );
 };


### PR DESCRIPTION
Removed colored dots from practitioner tabs after Alfie pointed out that they are remnants from a past mock-up. We are planning on using the same color scheme to include a daily overview for the practitioner (how many issues to check off, etc.).