### PR TITLE
Upcoming Appointment Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # Tuberculosis Treatment Support Tools:
+
 Development Branch Tests: [![CircleCI](https://circleci.com/gh/uwcirg/tb-mobile-app/tree/develop.svg?style=svg)](https://circleci.com/gh/uwcirg/tb-mobile-app/tree/develop)
 
 <img width="700px" alt="Screen Shot 2022-08-02 at 11 34 50 AM" src="https://user-images.githubusercontent.com/10137989/182414444-2bd00346-104f-469d-ad5a-4769aacc695b.png">
 
+## mHealth Intervention to support people with TB
 
-##  mHealth Intervention to support people with TB
 Tuberculosis remains one of the top ten causes of death globally despite it being largely curable. Patients face many challenges to adhere to treatment and mobile health (mHealth) interventions may address these challenges and support patients to complete their treatment. We aim to develop an application that has implications not only for TB adherence but disease management more generally and to improve our understanding of how to support patients throughout challenging treatment regimens.
 
-## Branches used in deployments 
-Pilot Study (2018 - 2019). Code available on the [v1-stable]([https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/v1-stable)) branch.
+## Branches used in deployments
 
-Clinical trial (2020 - Current). Code available on the [master]([https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/master)) branch.
+Pilot Study (2018 - 2019). Code available on the [v1-stable](<[https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/v1-stable)>) branch.
 
-Indonesian Pilot Study (2022 - Current). Code available on the [prod-id]([https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/prod-id)) branch.
+Clinical trial (2020 - Current). Code available on the [master](<[https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/master)>) branch.
 
+Indonesian Pilot Study (2022 - Current). Code available on the [prod-id](<[https://github.com/uwcirg/tb-mobile-app/tree/v1-stable](https://github.com/uwcirg/tb-mobile-app/tree/prod-id)>) branch.
 
-## System Components 
- 
+## System Components
+
 **Main Frontend:**
 React Application
 Code: [tb-mobile-app](https://github.com/uwcirg/tb-mobile-app) (this repo)
- 
-**Back End API:** 
+
+**Back End API:**
 Ruby on Rails App + Docker-Compose Deployment Configuration
 Code: [tb-foundation](https://github.com/uwcirg/tb-foundation)
-
 
 ## Tests
 
@@ -33,15 +33,16 @@ There are very minimal tests, but this could be an area to improve in the future
 Current tests use react-testing-library and there are important configuration files in `jest.config.js`,`src/testSetup.js `, and `package.json`
 
 To run the test suite run:
+
 ```
 yarn test
 ```
 
 To check coverage run:
+
 ```
 yarn test:coverage
 ```
-
 
 ## Getting started with development
 
@@ -51,9 +52,15 @@ Running the full application requires Docker. You will need to spin up the servi
 
 Once that process has completed, its best to run the React development server outside of docker like this:
 
-```
+```bash
 yarn install
 yarn start
+```
+
+If you are having node version issues, you can use nvm to install the correct version of node. We have set up a .nvmrc file to make this easier.
+
+```bash
+nvm use
 ```
 
 ## Production Build Process
@@ -74,6 +81,6 @@ Beacause this React app has been dockerized, the build process is a bit differen
 
 ## Contact
 
-[Sarah Iribarren](https://nursing.uw.edu/person/sarah-iribarren-phd-rn/) is the primary investegator for this research project, please reach out with any inquirys about research or collaboration. 
+[Sarah Iribarren](https://nursing.uw.edu/person/sarah-iribarren-phd-rn/) is the primary investegator for this research project, please reach out with any inquirys about research or collaboration.
 
 [Kyle Goodwin](https://github.com/kylegoodwin) lead most of the technical development, reach out with any technical questions.

--- a/src/Components/Shared/Appointments/AddAppointment/Form.js
+++ b/src/Components/Shared/Appointments/AddAppointment/Form.js
@@ -91,7 +91,7 @@ export default function Form({ state, setState, handleSubmit }) {
           {t("appointments.createAppointment")}
         </FlatButton>
       </Grid>
-      <Box height="2rem" aria-hidden />
+      <Box height="5rem" aria-hidden />
     </Box>
   );
 }

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -181,7 +181,11 @@ const PatientCard = ({
                       patientId={patient.id}
                     />
 
-                    {patient.nextReminder !== null ? (
+                    {patient.nextReminder !== null &&
+                    DateTime.fromISO(patient.nextReminder.datetime) <=
+                      DateTime.local().plus({ days: 5 }) &&
+                    DateTime.fromISO(patient.nextReminder.datetime) >=
+                      DateTime.local() ? (
                       <AppointmentReminder patient={patient} />
                     ) : (
                       <Box flexGrow={2} />
@@ -315,7 +319,7 @@ const ButtonArea = ({
 
   return (
     <Box padding="1em .5em">
-      <Grid wrap="nowrap" justify="flex-end" alignItems="center" container>
+      <Grid wrap="nowrap" alignItems="center" container>
         {disable && (
           <Box padding=".5em">
             <Typography className={classes.reviewPhotoPrompt}>

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -179,7 +179,35 @@ const PatientCard = ({
                       issues={patient.issues.state}
                       patientId={patient.id}
                     />
-                    <Box flexGrow={1} />
+                    {patient.nextReminder !== null ? (
+                      <Box
+                        flexGrow={1}
+                        display="flex"
+                        alignItems="flex-end"
+                        justifyContent="center"
+                      >
+                        {console.log(patient.nextReminder)}
+                        <Box paddingRight="1em">
+                          <Typography variant="body1">icons</Typography>
+                        </Box>
+                        <Box
+                          display="flex"
+                          flexDirection="column"
+                          alignItems="flex-start"
+                        >
+                          <Typography variant="body1">
+                            {DateTime.fromISO(
+                              patient.nextReminder.datetime
+                            ).toFormat("HH:mm LL-dd")}
+                          </Typography>
+                          <Typography variant="caption">
+                            {t("appointments.nextAppointment")}
+                          </Typography>
+                        </Box>
+                      </Box>
+                    ) : (
+                      <Box flexGrow={1} />
+                    )}
                     <Button className={classes.expand} onClick={toggleDetails}>
                       <Typography style={{ paddingRight: ".5em" }} noWrap>
                         {showDetails

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -180,69 +180,25 @@ const PatientCard = ({
                       issues={patient.issues.state}
                       patientId={patient.id}
                     />
+
                     {patient.nextReminder !== null ? (
-                      <Box flexGrow={1}>
-                        <Link
-                          to={`/patients/${patient.id}/appointments`}
-                          style={{ textDecoration: "none", color: "black" }}
-                        >
-                          <Box
-                            display="flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            flexWrap="wrap"
-                            paddingBottom={".2em"}
-                            paddingTop={".2em"}
-                            style={{
-                              border: `2px solid ${Colors.transparentBlueAccent}`,
-                              borderRadius: "5px",
-                              marginLeft: "1em",
-                              boxShadow: `2px 3px 4px rgba(0, 0, 0, 0.10)`,
-                            }}
-                          >
-                            <Box paddingRight="1em" color>
-                              <AccessTime fontSize="large" />
-                            </Box>
-                            <Box
-                              display="flex"
-                              flexDirection="column"
-                              alignItems="flex-start"
-                            >
-                              <Typography
-                                variant="body1"
-                                style={{
-                                  padding: ".2em",
-                                  marginX: ".5em",
-                                }}
-                              >
-                                {DateTime.fromISO(
-                                  patient.nextReminder.datetime
-                                ).toFormat("HH:mm dd/LL")}
-                              </Typography>
-                              <Typography
-                                variant="caption"
-                                style={{
-                                  textDecoration: "underline",
-                                  color: Colors.buttonBlue,
-                                }}
-                              >
-                                {t("appointments.nextAppointment")} &rarr;
-                              </Typography>
-                            </Box>
-                          </Box>
-                        </Link>
-                      </Box>
+                      <AppointmentReminder patient={patient} />
                     ) : (
-                      <Box flexGrow={1} />
+                      <Box flexGrow={2} />
                     )}
-                    <Button className={classes.expand} onClick={toggleDetails}>
-                      <Typography style={{ paddingRight: ".5em" }} noWrap>
-                        {showDetails
-                          ? t("messaging.moderation.hideUI")
-                          : t("reviewIssues.review")}
-                      </Typography>
-                      <Down className={showDetails ? classes.rotate : ""} />
-                    </Button>
+                    <Box flexGrow={1} display="flex" justifyContent="flex-end">
+                      <Button
+                        className={classes.expand}
+                        onClick={toggleDetails}
+                      >
+                        <Typography style={{ paddingRight: ".5em" }} noWrap>
+                          {showDetails
+                            ? t("messaging.moderation.hideUI")
+                            : t("reviewIssues.review")}
+                        </Typography>
+                        <Down className={showDetails ? classes.rotate : ""} />
+                      </Button>
+                    </Box>
                   </Grid>
                 ))}
             </Box>
@@ -291,6 +247,59 @@ const NoIssues = ({ resolvePatient, patient }) => {
         <Check style={{ color: Colors.green }} />
       </IconButton>
     </Grid>
+  );
+};
+
+const AppointmentReminder = ({ patient }) => {
+  const { t } = useTranslation("translation");
+  return (
+    <Box grow={1} padding=".2em .5em">
+      <Link
+        to={`/patients/${patient.id}/appointments`}
+        style={{ textDecoration: "none", color: "black" }}
+      >
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          flexWrap="wrap"
+          paddingBottom={".2em"}
+          paddingTop={".2em"}
+          style={{
+            border: `2px solid ${Colors.transparentBlueAccent}`,
+            borderRadius: "5px",
+            marginLeft: "1em",
+            boxShadow: `2px 3px 4px rgba(0, 0, 0, 0.10)`,
+          }}
+        >
+          <Box paddingRight="1em" color>
+            <AccessTime fontSize="large" />
+          </Box>
+          <Box display="flex" flexDirection="column" alignItems="center">
+            <Typography
+              variant="body1"
+              style={{
+                padding: ".2em",
+                marginX: ".5em",
+              }}
+            >
+              {DateTime.fromISO(patient.nextReminder.datetime).toFormat(
+                "HH:mm dd/LL"
+              )}
+            </Typography>
+            <Typography
+              variant="caption"
+              style={{
+                textDecoration: "underline",
+                color: Colors.buttonBlue,
+              }}
+            >
+              {t("appointments.nextAppointment")} &rarr;
+            </Typography>
+          </Box>
+        </Box>
+      </Link>
+    </Box>
   );
 };
 

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -14,6 +14,7 @@ import {
   Message,
   ArrowDropDownCircle as Down,
   CheckCircle,
+  AccessTime,
 } from "@material-ui/icons";
 import { Link } from "react-router-dom";
 import Colors from "../../Basics/Colors";
@@ -180,30 +181,56 @@ const PatientCard = ({
                       patientId={patient.id}
                     />
                     {patient.nextReminder !== null ? (
-                      <Box
-                        flexGrow={1}
-                        display="flex"
-                        alignItems="flex-end"
-                        justifyContent="center"
-                      >
-                        {console.log(patient.nextReminder)}
-                        <Box paddingRight="1em">
-                          <Typography variant="body1">icons</Typography>
-                        </Box>
-                        <Box
-                          display="flex"
-                          flexDirection="column"
-                          alignItems="flex-start"
+                      <Box flexGrow={1}>
+                        <Link
+                          to={`/patients/${patient.id}/appointments`}
+                          style={{ textDecoration: "none", color: "black" }}
                         >
-                          <Typography variant="body1">
-                            {DateTime.fromISO(
-                              patient.nextReminder.datetime
-                            ).toFormat("HH:mm LL-dd")}
-                          </Typography>
-                          <Typography variant="caption">
-                            {t("appointments.nextAppointment")}
-                          </Typography>
-                        </Box>
+                          <Box
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            flexWrap="wrap"
+                            paddingBottom={".2em"}
+                            paddingTop={".2em"}
+                            style={{
+                              border: `2px solid ${Colors.transparentBlueAccent}`,
+                              borderRadius: "5px",
+                              marginLeft: "1em",
+                              boxShadow: `2px 3px 4px rgba(0, 0, 0, 0.10)`,
+                            }}
+                          >
+                            <Box paddingRight="1em" color>
+                              <AccessTime fontSize="large" />
+                            </Box>
+                            <Box
+                              display="flex"
+                              flexDirection="column"
+                              alignItems="flex-start"
+                            >
+                              <Typography
+                                variant="body1"
+                                style={{
+                                  padding: ".2em",
+                                  marginX: ".5em",
+                                }}
+                              >
+                                {DateTime.fromISO(
+                                  patient.nextReminder.datetime
+                                ).toFormat("HH:mm dd/LL")}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                style={{
+                                  textDecoration: "underline",
+                                  color: Colors.buttonBlue,
+                                }}
+                              >
+                                {t("appointments.nextAppointment")} &rarr;
+                              </Typography>
+                            </Box>
+                          </Box>
+                        </Link>
                       </Box>
                     ) : (
                       <Box flexGrow={1} />

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -256,6 +256,7 @@ const NoIssues = ({ resolvePatient, patient }) => {
 
 const AppointmentReminder = ({ patient }) => {
   const { t } = useTranslation("translation");
+  const date = DateTime.fromISO(patient.nextReminder.datetime);
   return (
     <Box grow={1} padding=".2em .75em">
       <Link
@@ -269,13 +270,14 @@ const AppointmentReminder = ({ patient }) => {
           flexWrap="wrap"
           paddingBottom={".2em"}
           paddingTop={".2em"}
+          paddingX={".5em"}
           style={{
             border: `2px solid ${Colors.transparentBlueAccent}`,
             borderRadius: "5px",
             boxShadow: `2px 3px 4px rgba(0, 0, 0, 0.10)`,
           }}
         >
-          <Box paddingRight="1em" color>
+          <Box paddingRight=".15em" color>
             <AccessTime fontSize="large" />
           </Box>
           <Box display="flex" flexDirection="column" alignItems="center">
@@ -286,9 +288,13 @@ const AppointmentReminder = ({ patient }) => {
                 marginX: ".5em",
               }}
             >
-              {DateTime.fromISO(patient.nextReminder.datetime).toFormat(
-                "HH:mm dd/LL"
-              )}
+              {date.toLocaleString({
+                day: "numeric",
+                month: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                hourCycle: "h23",
+              })}
             </Typography>
             <Typography
               variant="caption"

--- a/src/Practitioner/ReviewPatients/PatientCard.js
+++ b/src/Practitioner/ReviewPatients/PatientCard.js
@@ -253,7 +253,7 @@ const NoIssues = ({ resolvePatient, patient }) => {
 const AppointmentReminder = ({ patient }) => {
   const { t } = useTranslation("translation");
   return (
-    <Box grow={1} padding=".2em .5em">
+    <Box grow={1} padding=".2em .75em">
       <Link
         to={`/patients/${patient.id}/appointments`}
         style={{ textDecoration: "none", color: "black" }}
@@ -268,7 +268,6 @@ const AppointmentReminder = ({ patient }) => {
           style={{
             border: `2px solid ${Colors.transparentBlueAccent}`,
             borderRadius: "5px",
-            marginLeft: "1em",
             boxShadow: `2px 3px 4px rgba(0, 0, 0, 0.10)`,
           }}
         >


### PR DESCRIPTION
- readME edited to reflect nvm solution to yarn start issues
- prelim steps to render next appointment information on patient card. needs icons and links to patient/id/appointment
- link to appointments, styles added. ready for approval?
- fully styled and responsive on different screens and under different conditions
- minor spacing tweaks
Asked for by Agnes. Since her team doesn't often navigate into the patient's profile, they were often 
surprised by patient appointments. Next Appointment is now rendered on the patient's card. Now that I think 
of it, we probably only want to render this button if the next appointment is within the next week, as to 
not clutter the space unnecesarilly.
